### PR TITLE
update redis version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 exclude = ["docker"]
 
 [dependencies]
-redis = { version = "^0.21.0", optional = true }
+redis = { version = "^0.22.1", optional = true }
 
 [features]
 default = ['redis']


### PR DESCRIPTION
currently the library is using the redis driver of version 0.21.0, so the traits are incompatible with the current version and the compiler yells at you 