### PR TITLE
bump redis library version to ^0.23.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-graph"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["tompro <office@protom.eu>"]
 keywords = ["redis", "database", "graph"]
 description = "API for Redis graph database types."
@@ -13,7 +13,7 @@ edition = "2018"
 exclude = ["docker"]
 
 [dependencies]
-redis = { version = "^0.22.1", optional = true }
+redis = { version = "^0.23.0", optional = true }
 
 [features]
 default = ['redis']

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ but should run with versions higher than that.
 
 ```ini
 [dependencies]
-redis = "0.22.1"
-redis-graph = "0.4.3"
+redis = "0.23.0"
+redis-graph = "0.4.4"
 ```
 
 Or via git:
@@ -34,8 +34,8 @@ With async feature inherited from the [redis](https://docs.rs/redis) crate (eith
 
 ```ini
 [dependencies]
-redis = "0.22.1"
-redis-graph = { version = "0.4.3", features = ['tokio-comp'] }
+redis = "0.23.0"
+redis-graph = { version = "0.4.4", features = ['tokio-comp'] }
 ```
 
 ## Synchronous usage


### PR DESCRIPTION
Bump Redis library version to `^0.23.0`. 

This fixes an incompatibility with `redis-graph = "0.4.3"` when it's used in a project that runs `redis = "0.23.0"`.